### PR TITLE
Forum creation bug fix

### DIFF
--- a/PetShelter-Backend/src/main/java/ca/mcgill/ecse321/petshelter/controller/ForumController.java
+++ b/PetShelter-Backend/src/main/java/ca/mcgill/ecse321/petshelter/controller/ForumController.java
@@ -48,6 +48,7 @@ public class ForumController {
 		forumDTO.setTitle(forum.getTitle());
 		forumDTO.setComments(comments);
 		forumDTO.setSubscribers(subscribers);
+		forumDTO.setAuthor(UserController.userToDto(forum.getAuthor()));
 		return forumDTO;
 	}
 	

--- a/PetShelter-Backend/src/main/java/ca/mcgill/ecse321/petshelter/model/Forum.java
+++ b/PetShelter-Backend/src/main/java/ca/mcgill/ecse321/petshelter/model/Forum.java
@@ -47,7 +47,7 @@ public class Forum {
         this.comments = commentss;
     }
     
-    @OneToMany
+    @ManyToMany
     public Set<User> getSubscribers() {
         return this.subscribers;
     }


### PR DESCRIPTION
The associations in the forum entity class were incompatible with their
intended use. According to the annotations, each user would only be
subscribed to one thread, however, it's clearly many-to-many as each
user can be subscibed to multiple threads and each threads can have
multiple subscribed users. Also, fix the entityToDto forum conversion to
also include the author.